### PR TITLE
Fix f-string escape in PNJ formatter

### DIFF
--- a/commands/pnj_generator_formatters.py
+++ b/commands/pnj_generator_formatters.py
@@ -105,7 +105,7 @@ Devotion: {details.get('info_extra', 'Serviteur fidèle')}"""
             return f"""Classe: {details.get('classe', 'Guerrier')}
 Niveau: {details.get('niveau_estime', 'Expérimenté')}
 Specialite: {details.get('specialite', 'Exploration')}
-Experience: {details.get('info_extra', 'Quelques années d\'aventure')}"""
+Experience: {details.get('info_extra', "Quelques années d'aventure")}"""
         
         elif type_pnj == "artisan":
             return f"""Metier: {details.get('metier', 'Artisan')}
@@ -171,7 +171,7 @@ Experience: {details.get('info_extra', 'Étudie la magie')}"""
             return f"""• **Classe :** {details.get('classe', 'Guerrier')}
 • **Niveau :** {details.get('niveau_estime', 'Expérimenté')}
 • **Spécialité :** {details.get('specialite', 'Exploration')}
-• **Expérience :** {details.get('info_extra', 'Quelques années d\'aventure')}"""
+• **Expérience :** {details.get('info_extra', "Quelques années d'aventure")}"""
         
         elif type_pnj == "artisan":
             return f"""• **Métier :** {details.get('metier', 'Artisan')}


### PR DESCRIPTION
## Summary
- fix syntax error in pnj formatter by using double-quoted default strings

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a6008cb9e883278d9a30630944aa17