### PR TITLE
Standardize quest reward section

### DIFF
--- a/web/maj-fiche-dev.html
+++ b/web/maj-fiche-dev.html
@@ -171,35 +171,28 @@
                                 </div>
 
                                 <div class="form-group">
-                                    <h5 style="color: #2c3e50; margin-bottom: 10px;">🎁 Récompenses obtenues :</h5>
-                                    <div id="recompenses-container-0">
-                                        <div class="recompense-item" data-recompense="0">
-                                            <select style="flex: 0 0 120px;">
-                                                <option value="monnaie" selected>💰 Monnaie</option>
-                                                <option value="item">🎒 Objet</option>
-                                            </select>
-                                            <div style="flex: 1; display: flex; gap: 5px;">
-                                                <input type="number" placeholder="PC" style="flex: 1;" value="0">
-                                                <input type="number" placeholder="PA" style="flex: 1;" value="0">
-                                                <input type="number" placeholder="PO" style="flex: 1;" value="150">
-                                                <input type="number" placeholder="PP" style="flex: 1;" value="0">
+                                    <h5 style="color: #2c3e50; margin-bottom: 10px;">🎁 Récompenses (optionnelles) :</h5>
+                                    <div class="reward-section">
+                                        <div class="reward-type">
+                                            <label>💰 Monnaies :</label>
+                                            <div class="monnaie-inputs" style="display: grid; grid-template-columns: 1fr 1fr 1fr 1fr; gap: 5px;">
+                                                <input type="number" id="pc-quete-0" placeholder="PC" min="0" value="0">
+                                                <input type="number" id="pa-quete-0" placeholder="PA" min="0" value="0">
+                                                <input type="number" id="po-quete-0" placeholder="PO" min="0" value="150">
+                                                <input type="number" id="pp-quete-0" placeholder="PP" min="0" value="0">
                                             </div>
-                                            <button type="button" class="delete-recompense">🗑️</button>
                                         </div>
-                                        <div class="recompense-item" data-recompense="1">
-                                            <select style="flex: 0 0 120px;">
-                                                <option value="monnaie">💰 Monnaie</option>
-                                                <option value="item" selected>🎒 Objet</option>
-                                            </select>
-                                            <div style="flex: 1; display: flex; gap: 5px;">
-                                                <input type="text" placeholder="Description" style="flex: 1;" value="Baguette de Boules de Feu (+1)">
-                                            </div>
-                                            <button type="button" class="delete-recompense">🗑️</button>
+
+                                        <div class="reward-type">
+                                            <label>🎒 Objets :</label>
+                                            <textarea id="objets-quete-0" rows="2" placeholder="2 émeraudes d'une valeur de 200PO, un étrange engrenage en rotation perpétuelle">Baguette de Boules de Feu (+1)</textarea>
+                                        </div>
+
+                                        <div class="reward-type">
+                                            <label>⭐ Autres récompenses :</label>
+                                            <textarea id="autres-quete-0" rows="2" placeholder="Don du fruit blanc à Kornélius, Sort Interdiction dans le grimoire"></textarea>
                                         </div>
                                     </div>
-                                    <button type="button" class="add-recompense" onclick="addRecompense(0)">
-                                        ➕ Ajouter une récompense
-                                    </button>
                                 </div>
 
                                 <button type="button" class="delete-quete" onclick="deleteQuete(0)" style="display: none;">

--- a/web/maj-fiche-script.js
+++ b/web/maj-fiche-script.js
@@ -21,7 +21,6 @@ const SPELL_LEARNING_COSTS = {
 
 // Variables globales
 let queteCounter = 0;
-let recompenseCounters = {}; // Pour tracker les compteurs de récompenses par quête
 
 // ===== GESTION DES ONGLETS =====
 


### PR DESCRIPTION
## Summary
- unify quest reward format using id-based `pc-quete-*` reward sections
- update initial dev HTML to match `createQueteHTML` structure
- drop unused reward counters variable

## Testing
- `pytest` *(fails: SyntaxError: f-string expression part cannot include a backslash)*

------
https://chatgpt.com/codex/tasks/task_e_68a602712d4c8327ae159377ffa08ae8