### PR TITLE
feat: add capacities and spells tab

### DIFF
--- a/web/maj-fiche-dev.html
+++ b/web/maj-fiche-dev.html
@@ -127,7 +127,7 @@
                     <div class="tab-buttons">
                         <button class="tab-btn active" onclick="showTab('quete', event)">🎯 Quête</button>
                         <button class="tab-btn" onclick="showTab('niveau', event)">📈 Niveau</button>
-                        <button class="tab-btn" onclick="showTab('sorts', event)">✨ Sorts</button>
+                        <button class="tab-btn" onclick="showTab('capacites', event)">🛡️ Capacités</button>
                         <button class="tab-btn" onclick="showTab('items', event)">🎒 Items</button>
                         <button class="tab-btn" onclick="showTab('argent', event)">💰 Argent</button>
                         <button class="tab-btn" onclick="showTab('special', event)">⭐ Spécial</button>
@@ -274,8 +274,21 @@
                     </div>
 
                     <!-- Autres onglets cachés pour la démo -->
-                    <div id="tab-sorts" class="tab-content">
-                        <p>🚧 Section Sorts en développement...</p>
+                    <div id="tab-capacites" class="tab-content">
+                        <div class="form-group">
+                            <label for="nouvelles-capacites">Nouvelles capacités / ASI :</label>
+                            <textarea id="nouvelles-capacites" rows="3" placeholder="Indiquez les nouvelles capacités ou ASI"></textarea>
+                        </div>
+                        <div class="form-group">
+                            <label for="nouveaux-sorts">Nouveaux sorts appris :</label>
+                            <textarea id="nouveaux-sorts" rows="3" placeholder="Un sort par ligne"></textarea>
+                            <div class="help-text">Une entrée par ligne</div>
+                        </div>
+                        <div class="form-group">
+                            <label for="sorts-remplaces">Sorts remplacés :</label>
+                            <textarea id="sorts-remplaces" rows="3" placeholder="Un sort par ligne"></textarea>
+                            <div class="help-text">Une entrée par ligne</div>
+                        </div>
                     </div>
                     <div id="tab-items" class="tab-content">
                         <p>🚧 Section Items en développement...</p>

--- a/web/maj-fiche-script.js
+++ b/web/maj-fiche-script.js
@@ -636,12 +636,19 @@ ${questesText}
     
     // Sorts et capacités
     const nouvellesCapacitesEl = document.getElementById('nouvelles-capacites');
-    const nouveauSortsEl = document.getElementById('nouveaux-sorts');
-    const sortRemplaceEl = document.getElementById('sort-remplace');
-    
+    const nouveauxSortsEl = document.getElementById('nouveaux-sorts');
+    const sortsRemplacesEl = document.getElementById('sorts-remplaces');
+
+    const parseList = (el) => {
+        if (!el || !el.value) return [];
+        return el.value.split(/[\n,]+/).map(s => s.trim()).filter(Boolean);
+    };
+
     const nouvellesCapacites = nouvellesCapacitesEl ? nouvellesCapacitesEl.value || '-' : '-';
-    const nouveauSorts = nouveauSortsEl ? nouveauSortsEl.value || '-' : '-';
-    const sortRemplace = sortRemplaceEl ? sortRemplaceEl.value || '-' : '-';
+    const nouveauxSortsList = parseList(nouveauxSortsEl);
+    const sortsRemplacesList = parseList(sortsRemplacesEl);
+    const nouveauxSorts = nouveauxSortsList.length ? nouveauxSortsList.join(', ') : '-';
+    const sortsRemplaces = sortsRemplacesList.length ? sortsRemplacesList.join(', ') : '-';
     
     // Items et argent
     const objetsLootesEl = document.getElementById('objets-lootes');
@@ -713,9 +720,9 @@ ${affichageXP}`;
 Nouvelle(s) capacité(s) :
 ${nouvellesCapacites}
 Nouveau(x) sort(s) :
-${nouveauSorts}
-Sort remplacé :
-${sortRemplace}`;
+${nouveauxSorts}
+Sort(s) remplacé(s) :
+${sortsRemplaces}`;
 
     // Inventaire seulement si renseigné
     const objetsLootesBase = objetsLootes || '';

--- a/web/maj-fiche-styles.css
+++ b/web/maj-fiche-styles.css
@@ -216,6 +216,10 @@ input:focus, select:focus, textarea:focus {
     display: block;
 }
 
+#tab-capacites textarea {
+    min-height: 60px;
+}
+
 /* Gestion des quêtes */
 .quete-bloc {
     background: #f8f9fa;


### PR DESCRIPTION
## Summary
- rename Sorts tab to Capacités with fields for new capacities, learned spells, and replacements
- parse and display lists of learned and replaced spells in template generation
- style new Capacités tab and text areas

## Testing
- `npm test` *(fails: could not read package.json)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6546423f48327b81d93e7eabd5d0c