### PR TITLE
feat: add feat fields to update template

### DIFF
--- a/web/maj-fiche-dev.html
+++ b/web/maj-fiche-dev.html
@@ -280,6 +280,14 @@
                             <textarea id="nouvelles-capacites" rows="3" placeholder="Indiquez les nouvelles capacités ou ASI"></textarea>
                         </div>
                         <div class="form-group">
+                            <label for="nouveau-don">Nouveau(x) don(s) (niveau/ASI) :</label>
+                            <textarea id="nouveau-don" rows="3" placeholder="Indiquez les dons obtenus"></textarea>
+                        </div>
+                        <div class="form-group">
+                            <label for="don-quete">Don(s) (gain de quête) :</label>
+                            <textarea id="don-quete" rows="3" placeholder="Indiquez les dons obtenus en récompense de quête"></textarea>
+                        </div>
+                        <div class="form-group">
                             <label for="nouveaux-sorts">Nouveaux sorts appris :</label>
                             <textarea id="nouveaux-sorts" rows="3" placeholder="Un sort par ligne"></textarea>
                             <div class="help-text">Une entrée par ligne</div>

--- a/web/maj-fiche-script.js
+++ b/web/maj-fiche-script.js
@@ -636,6 +636,8 @@ ${questesText}
     
     // Sorts et capacités
     const nouvellesCapacitesEl = document.getElementById('nouvelles-capacites');
+    const nouveauDonEl = document.getElementById('nouveau-don');
+    const donQueteEl = document.getElementById('don-quete');
     const nouveauxSortsEl = document.getElementById('nouveaux-sorts');
     const sortsRemplacesEl = document.getElementById('sorts-remplaces');
 
@@ -645,8 +647,12 @@ ${questesText}
     };
 
     const nouvellesCapacites = nouvellesCapacitesEl ? nouvellesCapacitesEl.value || '-' : '-';
+    const nouveauDonList = parseList(nouveauDonEl);
+    const donQueteList = parseList(donQueteEl);
     const nouveauxSortsList = parseList(nouveauxSortsEl);
     const sortsRemplacesList = parseList(sortsRemplacesEl);
+    const nouveauxDons = nouveauDonList.length ? nouveauDonList.join(', ') : '-';
+    const donsQuete = donQueteList.length ? donQueteList.join(', ') : '-';
     const nouveauxSorts = nouveauxSortsList.length ? nouveauxSortsList.join(', ') : '-';
     const sortsRemplaces = sortsRemplacesList.length ? sortsRemplacesList.join(', ') : '-';
     
@@ -719,6 +725,10 @@ ${affichageXP}`;
 **¤ Capacités et sorts supplémentaires :**
 Nouvelle(s) capacité(s) :
 ${nouvellesCapacites}
+Nouveau(x) don(s) :
+${nouveauxDons}
+Don(s) (gain de quête) :
+${donsQuete}
 Nouveau(x) sort(s) :
 ${nouveauxSorts}
 Sort(s) remplacé(s) :
@@ -875,7 +885,7 @@ document.addEventListener('DOMContentLoaded', function() {
     setupQueteListeners(0);
     
     // Listeners pour tous les autres champs
-    const inputs = document.querySelectorAll('input:not([id*="quete"]):not([data-listener-added]), select:not([data-listener-added]), textarea:not([id*="quete"]):not([data-listener-added])');
+    const inputs = document.querySelectorAll('input:not([id*="quete"]):not([data-listener-added]), select:not([data-listener-added]), textarea:not([id*="quete"]):not([data-listener-added]), textarea#don-quete:not([data-listener-added])');
     inputs.forEach(input => {
         input.addEventListener('input', regenerateIfNeeded);
         input.setAttribute('data-listener-added', 'true');


### PR DESCRIPTION
## Summary
- add form fields for level-up and quest feats
- include new feat sections in generated Discord template
- auto-refresh template when quest feat field changes

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check web/maj-fiche-script.js`


------
https://chatgpt.com/codex/tasks/task_e_68a655542c0883279e494436765e26f6