### PR TITLE
Add inventory and currency fields

### DIFF
--- a/web/maj-fiche-dev.html
+++ b/web/maj-fiche-dev.html
@@ -299,10 +299,39 @@
                         </div>
                     </div>
                     <div id="tab-items" class="tab-content">
-                        <p>🚧 Section Items en développement...</p>
+                        <div class="form-group">
+                            <label for="objets-lootes">Objets lootés (hors quêtes) :</label>
+                            <textarea id="objets-lootes" rows="3" placeholder="Une ligne par objet"></textarea>
+                            <div class="help-text">Une ligne par objet looté hors quête.</div>
+                        </div>
+                        <div class="form-group">
+                            <label for="achats-ventes">Achats / Ventes :</label>
+                            <textarea id="achats-ventes" rows="3" placeholder="Achat de composant X : 100 PO"></textarea>
+                            <div class="help-text">Une ligne par achat/vente (ex. « Achat de composant X : 100 PO »)</div>
+                        </div>
                     </div>
                     <div id="tab-argent" class="tab-content">
-                        <p>🚧 Section Argent en développement...</p>
+                        <div class="argent-grid">
+                            <div class="form-group">
+                                <label for="po-lootees">PO lootées (hors quêtes) :</label>
+                                <input type="number" id="po-lootees" placeholder="0">
+                            </div>
+                            <div class="form-group">
+                                <label for="po-recues">PO reçues / dépensées :</label>
+                                <input type="number" id="po-recues" placeholder="0">
+                                <div class="help-text">Valeurs négatives possibles</div>
+                            </div>
+                            <div class="form-group">
+                                <label for="ancien-solde">Ancien solde :</label>
+                                <input type="text" id="ancien-solde" placeholder="Solde avant session">
+                            </div>
+                            <div class="form-group">
+                                <label for="section-marchand">
+                                    <input type="checkbox" id="section-marchand" style="width: auto; margin-right: 8px;">
+                                    Activer le bloc Marchand
+                                </label>
+                            </div>
+                        </div>
                     </div>
                     <div id="tab-special" class="tab-content">
                         <p>🚧 Section Spécial en développement...</p>

--- a/web/maj-fiche-script.js
+++ b/web/maj-fiche-script.js
@@ -662,8 +662,9 @@ ${questesText}
     const achatsVentesEl = document.getElementById('achats-ventes');
     const ancienSoldeEl = document.getElementById('ancien-solde');
     const poRecuesEl = document.getElementById('po-recues');
-    
-    const objetsLootes = objetsLootesEl ? objetsLootesEl.value || '' : '';
+
+    const objetsLootesList = objetsLootesEl ? parseList(objetsLootesEl) : [];
+    const objetsLootes = objetsLootesList.length ? objetsLootesList.join(', ') : '';
     const poLootees = poLootesEl ? parseInt(poLootesEl.value) || 0 : 0;
     const achatsVentes = achatsVentesEl ? achatsVentesEl.value || '' : '';
     const ancienSolde = ancienSoldeEl ? ancienSoldeEl.value || '[ANCIEN_SOLDE]' : '[ANCIEN_SOLDE]';
@@ -772,12 +773,11 @@ Monnaies lootées: ${monnaiesText}`;
 ** \\ =======================  PJ  ========================= / **`;
 
     // Section Marchand si demandée
-    if (includeMarchand && achatsVentes !== '') {
+    if (includeMarchand && achatsVentes.trim() !== '') {
         template += `
-**/ ===================== Marchand ===================== \\ **
-**¤ Inventaire**
+/ =======================  MARCHAND  ========================= \\
 ${achatsVentes}
-** \\ ==================== Marchand ====================== / **`;
+\\ =======================  MARCHAND  ========================= /`;
     }
 
     // Calcul nouveau solde
@@ -885,7 +885,18 @@ document.addEventListener('DOMContentLoaded', function() {
     setupQueteListeners(0);
     
     // Listeners pour tous les autres champs
-    const inputs = document.querySelectorAll('input:not([id*="quete"]):not([data-listener-added]), select:not([data-listener-added]), textarea:not([id*="quete"]):not([data-listener-added]), textarea#don-quete:not([data-listener-added])');
+    const inputs = document.querySelectorAll(
+        'input:not([id*="quete"]):not([data-listener-added]),'
+        + ' select:not([data-listener-added]),'
+        + ' textarea:not([id*="quete"]):not([data-listener-added]),'
+        + ' textarea#don-quete:not([data-listener-added]),'
+        + ' textarea#objets-lootes:not([data-listener-added]),'
+        + ' textarea#achats-ventes:not([data-listener-added]),'
+        + ' input#po-lootees:not([data-listener-added]),'
+        + ' input#po-recues:not([data-listener-added]),'
+        + ' input#ancien-solde:not([data-listener-added]),'
+        + ' input#section-marchand:not([data-listener-added])'
+    );
     inputs.forEach(input => {
         input.addEventListener('input', regenerateIfNeeded);
         input.setAttribute('data-listener-added', 'true');

--- a/web/maj-fiche-styles.css
+++ b/web/maj-fiche-styles.css
@@ -220,6 +220,24 @@ input:focus, select:focus, textarea:focus {
     min-height: 60px;
 }
 
+/* Items et Argent */
+#tab-items textarea {
+    min-height: 60px;
+    resize: vertical;
+}
+
+#tab-argent .argent-grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 15px;
+}
+
+@media (min-width: 768px) {
+    #tab-argent .argent-grid {
+        grid-template-columns: repeat(2, 1fr);
+    }
+}
+
 /* Gestion des quêtes */
 .quete-bloc {
     background: #f8f9fa;


### PR DESCRIPTION
## Summary
- expand Items and Argent tabs with inventory and currency fields
- generate Marchand block and parse extra loot fields
- style new sections for responsive layout

## Testing
- `node --check web/maj-fiche-script.js`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a65783eaf4832781913dfe948e6fb9