### PR TITLE
Allow negative quest currency

### DIFF
--- a/web/maj-fiche-dev.html
+++ b/web/maj-fiche-dev.html
@@ -181,11 +181,12 @@
                                     </div>
                                     <div id="monnaie-container-0" style="display: none;">
                                         <div class="monnaie-inputs" style="display: grid; grid-template-columns: 1fr 1fr 1fr 1fr; gap: 5px;">
-                                            <input type="number" id="pc-quete-0" placeholder="PC" min="0">
-                                            <input type="number" id="pa-quete-0" placeholder="PA" min="0">
-                                            <input type="number" id="po-quete-0" placeholder="PO" min="0">
-                                            <input type="number" id="pp-quete-0" placeholder="PP" min="0">
+                                            <input type="number" id="pc-quete-0" placeholder="PC">
+                                            <input type="number" id="pa-quete-0" placeholder="PA">
+                                            <input type="number" id="po-quete-0" placeholder="PO">
+                                            <input type="number" id="pp-quete-0" placeholder="PP">
                                         </div>
+                                        <input type="text" id="total-quete-or-0" placeholder="Total en PO" disabled style="margin-top: 5px;">
                                     </div>
 
                                     <div class="checkbox-group">
@@ -324,6 +325,10 @@
                             <div class="form-group">
                                 <label for="ancien-solde">Ancien solde :</label>
                                 <input type="text" id="ancien-solde" placeholder="Solde avant session">
+                            </div>
+                            <div class="form-group">
+                                <label for="total-or">Total en or :</label>
+                                <input type="text" id="total-or" placeholder="0 PO" disabled>
                             </div>
                             <div class="form-group">
                                 <label for="section-marchand">

--- a/web/maj-fiche-script.js
+++ b/web/maj-fiche-script.js
@@ -243,11 +243,12 @@ function createQueteHTML(index) {
             </div>
             <div id="monnaie-container-${index}" style="display: none;">
                 <div class="monnaie-inputs" style="display: grid; grid-template-columns: 1fr 1fr 1fr 1fr; gap: 5px;">
-                    <input type="number" id="pc-quete-${index}" placeholder="PC" min="0">
-                    <input type="number" id="pa-quete-${index}" placeholder="PA" min="0">
-                    <input type="number" id="po-quete-${index}" placeholder="PO" min="0">
-                    <input type="number" id="pp-quete-${index}" placeholder="PP" min="0">
+                    <input type="number" id="pc-quete-${index}" placeholder="PC">
+                    <input type="number" id="pa-quete-${index}" placeholder="PA">
+                    <input type="number" id="po-quete-${index}" placeholder="PO">
+                    <input type="number" id="pp-quete-${index}" placeholder="PP">
                 </div>
+                <input type="text" id="total-quete-or-${index}" placeholder="Total en PO" disabled style="margin-top: 5px;">
             </div>
 
             <div class="checkbox-group">
@@ -271,6 +272,23 @@ function createQueteHTML(index) {
             </button>
         </div>
     `;
+}
+
+function updateMonnaieTotal(index) {
+    const pcEl = document.getElementById(`pc-quete-${index}`);
+    const paEl = document.getElementById(`pa-quete-${index}`);
+    const poEl = document.getElementById(`po-quete-${index}`);
+    const ppEl = document.getElementById(`pp-quete-${index}`);
+    const totalEl = document.getElementById(`total-quete-or-${index}`);
+    if (!totalEl) return;
+
+    const pc = pcEl ? parseInt(pcEl.value) || 0 : 0;
+    const pa = paEl ? parseInt(paEl.value) || 0 : 0;
+    const po = poEl ? parseInt(poEl.value) || 0 : 0;
+    const pp = ppEl ? parseInt(ppEl.value) || 0 : 0;
+
+    const totalPO = po + (pa / 10) + (pc / 100) + (pp * 10);
+    totalEl.value = totalPO === 0 ? '' : `${totalPO.toFixed(2)} PO`;
 }
 
 function setupQueteListeners(index) {
@@ -303,6 +321,11 @@ function setupQueteListeners(index) {
             if (container) {
                 container.style.display = this.checked ? 'block' : 'none';
             }
+            if (!this.checked) {
+                const totalEl = document.getElementById(`total-quete-or-${index}`);
+                if (totalEl) totalEl.value = '';
+            }
+            updateMonnaieTotal(index);
             regenerateIfNeeded();
         };
         includeMonnaies.addEventListener('change', updateMonnaies);
@@ -331,6 +354,19 @@ function setupQueteListeners(index) {
             input.setAttribute('data-listener-added', 'true');
         }
     });
+
+    const pcInput = document.getElementById(`pc-quete-${index}`);
+    const paInput = document.getElementById(`pa-quete-${index}`);
+    const poInput = document.getElementById(`po-quete-${index}`);
+    const ppInput = document.getElementById(`pp-quete-${index}`);
+    [pcInput, paInput, poInput, ppInput].forEach(inp => {
+        if (inp && !inp.hasAttribute('data-total-listener')) {
+            inp.addEventListener('input', () => updateMonnaieTotal(index));
+            inp.setAttribute('data-total-listener', 'true');
+        }
+    });
+
+    updateMonnaieTotal(index);
 
     const addBtn = document.querySelector(`[data-quete="${index}"] .add-recompense`);
     const recompenseContainer = document.getElementById(`recompenses-container-${index}`);
@@ -745,14 +781,21 @@ ${sortsRemplaces}`;
     const totalPA = totalMonnaies.PA;
     const totalPO = totalMonnaies.PO + poLootees;
     const totalPP = totalMonnaies.PP;
-    
+
+    const totalLootPO = totalPO + (totalPA / 10) + (totalPC / 100) + (totalPP * 10);
+
+    const totalOrEl = document.getElementById('total-or');
+    if (totalOrEl) {
+        totalOrEl.value = `${totalLootPO.toFixed(2)} PO`;
+    }
+
     // Construire le texte des monnaies lootées
     let monnaiesLootees = [];
     if (totalPC !== 0) monnaiesLootees.push(`${totalPC > 0 ? '+' : ''}${totalPC} PC`);
     if (totalPA !== 0) monnaiesLootees.push(`${totalPA > 0 ? '+' : ''}${totalPA} PA`);
     if (totalPO !== 0) monnaiesLootees.push(`${totalPO > 0 ? '+' : ''}${totalPO} PO`);
     if (totalPP !== 0) monnaiesLootees.push(`${totalPP > 0 ? '+' : ''}${totalPP} PP`);
-    
+
     const monnaiesText = monnaiesLootees.length > 0 ? monnaiesLootees.join(' ') : '';
     
     if (tousObjets !== '' || monnaiesText !== '') {
@@ -781,7 +824,7 @@ ${achatsVentes}
     }
 
     // Calcul nouveau solde
-    const changeTotal = poRecues + (poLootees + totalMonnaies.PO);
+    const changeTotal = poRecues + totalLootPO;
     let nouveauSolde;
     if (changeTotal === 0) {
         nouveauSolde = `${ancienSolde} inchangé`;


### PR DESCRIPTION
## Summary
- Remove min limits from quest currency inputs to accept negative values
- Ensure negative currency deltas display with signs in quest summaries
- Add read-only gold totals with cross-currency conversion

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'discord')*

------
https://chatgpt.com/codex/tasks/task_e_68a6e63718a48327a15563d6a813aa79