### PR TITLE
feat: parse merchant operations in template

### DIFF
--- a/web/maj-fiche-dev.html
+++ b/web/maj-fiche-dev.html
@@ -308,7 +308,7 @@
                         <div class="form-group">
                             <label for="achats-ventes">Achats / Ventes :</label>
                             <textarea id="achats-ventes" rows="3" placeholder="Achat de composant X : 100 PO"></textarea>
-                            <div class="help-text">Une ligne par achat/vente (ex. « Achat de composant X : 100 PO »)</div>
+                            <div class="help-text">Format : ACHAT : Armure 45PO / VENTE : Bijou 100PO</div>
                         </div>
                     </div>
                     <div id="tab-argent" class="tab-content">


### PR DESCRIPTION
## Summary
- add `parseAchatsVentes` to format merchant buy/sell entries and compute net gold
- include merchant net gold in balance calculation and show formatted operations
- document expected format for merchant entries

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6efc054dc8327a21232645db5539a