### PR TITLE
feat: add dynamic transaction lines

### DIFF
--- a/web/maj-fiche-dev.html
+++ b/web/maj-fiche-dev.html
@@ -311,8 +311,9 @@
                             <div class="help-text">Une ligne par objet looté hors quête.</div>
                         </div>
                         <div class="form-group">
-                            <label for="achats-ventes">Achats / Ventes :</label>
-                            <textarea id="achats-ventes" rows="3" placeholder="Achat de composant X : 100 PO"></textarea>
+                            <label>Achats / Ventes :</label>
+                            <div id="transactions-container"></div>
+                            <button type="button" id="add-transaction">Ajouter une ligne</button>
                             <div class="help-text">Format : ACHAT : Armure 45PO / VENTE : Bijou 100PO</div>
                         </div>
                     </div>

--- a/web/maj-fiche-styles.css
+++ b/web/maj-fiche-styles.css
@@ -284,6 +284,56 @@ input[disabled] {
     background: #c0392b;
 }
 
+/* Achats / Ventes */
+#transactions-container {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    margin-bottom: 5px;
+}
+
+.transaction-line {
+    display: grid;
+    grid-template-columns: 100px 1fr 100px 40px;
+    gap: 5px;
+    align-items: center;
+}
+
+.transaction-line select,
+.transaction-line input[type="text"],
+.transaction-line input[type="number"] {
+    padding: 6px;
+}
+
+.transaction-line button.delete-transaction {
+    background: #e74c3c;
+    color: white;
+    border: none;
+    padding: 4px 8px;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+.transaction-line button.delete-transaction:hover {
+    background: #c0392b;
+}
+
+#add-transaction {
+    background: #3498db;
+    color: white;
+    border: none;
+    padding: 6px 12px;
+    border-radius: 4px;
+    font-size: 12px;
+    cursor: pointer;
+    margin-top: 5px;
+    transition: background 0.3s ease;
+}
+
+#add-transaction:hover {
+    background: #2980b9;
+}
+
 /* Récompenses */
 .recompense-item {
     display: flex;


### PR DESCRIPTION
## Summary
- replace Achats/Ventes textarea with dynamic transaction lines
- support merchant transactions in template generation
- style transaction entries and controls

## Testing
- `pytest`
- `npm test` *(fails: Could not read package.json)*
- `node --check web/maj-fiche-script.js`

------
https://chatgpt.com/codex/tasks/task_e_68a747fd58f08327934fe7c4d7bec144