### PR TITLE
Use float for loot and received gold

### DIFF
--- a/web/maj-fiche-script.js
+++ b/web/maj-fiche-script.js
@@ -773,7 +773,7 @@ ${questesText}
 
     const objetsLootesList = objetsLootesEl ? parseList(objetsLootesEl) : [];
     const objetsLootes = objetsLootesList.length ? objetsLootesList.join(', ') : '';
-    const poLootees = poLootesEl ? parseInt(poLootesEl.value) || 0 : 0;
+    const poLootees = poLootesEl ? parseFloat(poLootesEl.value) || 0 : 0;
     let transactionsText = '';
     let netPOMarchand = 0;
 
@@ -799,7 +799,7 @@ ${questesText}
 
     const ancienSolde = ancienSoldeEl ? ancienSoldeEl.value || '[ANCIEN_SOLDE]' : '[ANCIEN_SOLDE]';
     const ancienSoldeNum = parseFloat(ancienSolde);
-    const poRecues = poRecuesEl ? parseInt(poRecuesEl.value) || 0 : 0;
+    const poRecues = poRecuesEl ? parseFloat(poRecuesEl.value) || 0 : 0;
     
     // Section spéciale
     const typeSpecialEl = document.getElementById('type-special');


### PR DESCRIPTION
## Summary
- preserve decimal amounts when reading loot and received gold inputs

## Testing
- `npm test` *(fails: Could not read package.json)*
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a757bc8cd08327a7e5562e14b5b210