### PR TITLE
Remove unused transaction index

### DIFF
--- a/web/maj-fiche-script.js
+++ b/web/maj-fiche-script.js
@@ -22,7 +22,6 @@ const SPELL_LEARNING_COSTS = {
 // Variables globales
 let queteCounter = 0;
 let recompenseCounters = {}; // Pour tracker les compteurs de récompenses par quête
-let transactionCounter = 0;
 
 // ===== GESTION DES ONGLETS =====
 
@@ -53,7 +52,6 @@ function addTransactionLine() {
 
     const line = document.createElement('div');
     line.className = 'transaction-line';
-    line.dataset.index = transactionCounter++;
     line.innerHTML = `
         <select>
             <option value="ACHAT">ACHAT</option>


### PR DESCRIPTION
## Summary
- drop unused `transactionCounter` and `data-index` attributes from transaction lines

## Testing
- `pytest` *(fails: command not found)*
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a7589473f08327ab7ac6e65e878622