### PR TITLE
Add change listener for transaction selects

### DIFF
--- a/web/maj-fiche-script.js
+++ b/web/maj-fiche-script.js
@@ -79,6 +79,9 @@ function setupTransactionLine(line) {
     inputs.forEach(inp => {
         if (!inp.getAttribute('data-listener-added')) {
             inp.addEventListener('input', regenerateIfNeeded);
+            if (inp.tagName === 'SELECT') {
+                inp.addEventListener('change', regenerateIfNeeded);
+            }
             inp.setAttribute('data-listener-added', 'true');
         }
     });


### PR DESCRIPTION
## Summary
- Ensure transaction lines re-render when select boxes change

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a75d71ab4c8327b0f5c11d4b5bab1b