### PR TITLE
Add artisanat crafting inputs and template generation

### DIFF
--- a/web/maj-fiche-dev.html
+++ b/web/maj-fiche-dev.html
@@ -345,7 +345,18 @@
                         </div>
                     </div>
                     <div id="tab-special" class="tab-content">
-                        <p>🚧 Section Spécial en développement...</p>
+                        <div class="form-group">
+                            <label for="artisanat-notes">Notes d'artisanat :</label>
+                            <textarea id="artisanat-notes" rows="3" placeholder="Notes sur l'artisanat..."></textarea>
+                        </div>
+                        <div class="form-group">
+                            <label for="artisanat-items">Objets fabriqués (un par ligne) :</label>
+                            <textarea id="artisanat-items" rows="3" placeholder="Potion de soin\nPotion de mana"></textarea>
+                        </div>
+                        <div class="form-group">
+                            <label for="artisanat-cost">Coût total d'artisanat :</label>
+                            <input type="number" id="artisanat-cost" placeholder="0">
+                        </div>
                     </div>
                 </div>
 

--- a/web/maj-fiche-script.js
+++ b/web/maj-fiche-script.js
@@ -801,6 +801,16 @@ ${questesText}
     const ancienSolde = ancienSoldeEl ? ancienSoldeEl.value || '[ANCIEN_SOLDE]' : '[ANCIEN_SOLDE]';
     const ancienSoldeNum = parseFloat(ancienSolde);
     const poRecues = poRecuesEl ? parseFloat(poRecuesEl.value) || 0 : 0;
+
+    // Artisanat
+    const artisanatNotesEl = document.getElementById('artisanat-notes');
+    const artisanatItemsEl = document.getElementById('artisanat-items');
+    const artisanatCostEl = document.getElementById('artisanat-cost');
+
+    const artisanatNotes = artisanatNotesEl ? artisanatNotesEl.value.trim() : '';
+    const artisanatItemsList = artisanatItemsEl ? parseList(artisanatItemsEl) : [];
+    const artisanatCostRaw = artisanatCostEl ? artisanatCostEl.value.trim() : '';
+    const artisanatCost = artisanatCostRaw !== '' ? parseFloat(artisanatCostRaw) || 0 : 0;
     
     // Section spéciale
     const typeSpecialEl = document.getElementById('type-special');
@@ -944,6 +954,27 @@ ${transactionsText}
 ANCIEN SOLDE ${soldeText}
 *Fiche R20 à jour.*`;
 
+    const hasArtisanat = artisanatNotes || artisanatItemsList.length > 0 || artisanatCostRaw !== '';
+    if (hasArtisanat) {
+        template += `
+**Artisanat :** ${artisanatNotes}`;
+        if (artisanatItemsList.length > 0) {
+            template += `
+Obtention des objets suivants :
+${artisanatItemsList.map(i => `- ${i}`).join('\n')}`;
+        }
+        const nouveauSoldeNum = parseFloat(nouveauSoldeCalc);
+        const artisanatCostFormatted = artisanatCost.toFixed(2);
+        if (!isNaN(nouveauSoldeNum)) {
+            const soldeApresArtisanat = (nouveauSoldeNum - artisanatCost).toFixed(2);
+            template += `
+${nouveauSoldeCalc} - ${artisanatCostFormatted} = ${soldeApresArtisanat}`;
+        } else {
+            template += `
+${nouveauSoldeCalc} - ${artisanatCostFormatted} = [SOLDE_ARTISANAT]`;
+        }
+    }
+
     const outputEl = document.getElementById('discord-output');
     if (outputEl) {
         outputEl.textContent = template;
@@ -1050,6 +1081,9 @@ document.addEventListener('DOMContentLoaded', function() {
         + ' input#po-lootees:not([data-listener-added]),'
         + ' input#po-recues:not([data-listener-added]),'
         + ' input#ancien-solde:not([data-listener-added]),'
+        + ' textarea#artisanat-notes:not([data-listener-added]),'
+        + ' textarea#artisanat-items:not([data-listener-added]),'
+        + ' input#artisanat-cost:not([data-listener-added]),'
         + ' input#section-marchand:not([data-listener-added])'
     );
     inputs.forEach(input => {


### PR DESCRIPTION
## Summary
- add artisanat notes, items, and cost inputs on the special tab
- generate artisanat section in Discord template and adjust balance
- hook artisanat fields into auto-regeneration listeners

## Testing
- `pytest`
- `node test snippet for artisanat section`


------
https://chatgpt.com/codex/tasks/task_e_68a763467db88327879319e3b8020749