### PR TITLE
feat: add character count indicator

### DIFF
--- a/web/maj-fiche-dev.html
+++ b/web/maj-fiche-dev.html
@@ -367,6 +367,7 @@
 
             <div class="output-section">
                 <h3 class="preview-title">📝 Aperçu Discord</h3>
+                <div id="char-indicator" class="char-indicator"></div>
                 <div class="discord-output" id="discord-output">Nom du PJ : Gandalf le Gris
 Classe : Magicien
 

--- a/web/maj-fiche-script.js
+++ b/web/maj-fiche-script.js
@@ -979,6 +979,13 @@ ${nouveauSoldeCalc} - ${artisanatCostFormatted} = [SOLDE_ARTISANAT]`;
     const outputPart2El = document.getElementById('discord-output-part2');
     const copyBtnPart2 = document.getElementById('copy-btn-part2');
     const templateLength = template.length;
+    const remaining = 1800 - templateLength;
+    const indicator = document.getElementById('char-indicator');
+    if (indicator) {
+        indicator.textContent = `${remaining} caractères restants`;
+        const nearLimit = remaining < 0 || remaining < 100;
+        indicator.classList.toggle('warning', nearLimit);
+    }
 
     if (templateLength > 1800) {
         alert("Le message dépasse 1 800 caractères. Il est divisé en deux parties.");

--- a/web/maj-fiche-styles.css
+++ b/web/maj-fiche-styles.css
@@ -184,6 +184,17 @@ input[disabled] {
     gap: 10px;
 }
 
+.char-indicator {
+    font-size: 12px;
+    margin-bottom: 10px;
+    color: rgba(255,255,255,0.8);
+}
+
+.char-indicator.warning {
+    color: #e74c3c;
+    font-weight: bold;
+}
+
 /* Système d'onglets */
 .tab-container {
     margin-bottom: 20px;


### PR DESCRIPTION
## Summary
- show remaining characters near preview
- update generator script to track remaining count and warn near limit
- style new counter with warning state

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a7758243b48327b8c1dfd3caee8afe