### PR TITLE
Add split warning for long templates

### DIFF
--- a/web/maj-fiche-dev.html
+++ b/web/maj-fiche-dev.html
@@ -368,6 +368,7 @@
             <div class="output-section">
                 <h3 class="preview-title">📝 Aperçu Discord</h3>
                 <div id="char-indicator" class="char-indicator"></div>
+                <div id="split-warning" class="split-warning" style="display:none;"></div>
                 <div class="discord-output" id="discord-output">Nom du PJ : Gandalf le Gris
 Classe : Magicien
 

--- a/web/maj-fiche-script.js
+++ b/web/maj-fiche-script.js
@@ -978,6 +978,7 @@ ${nouveauSoldeCalc} - ${artisanatCostFormatted} = [SOLDE_ARTISANAT]`;
     const outputEl = document.getElementById('discord-output');
     const outputPart2El = document.getElementById('discord-output-part2');
     const copyBtnPart2 = document.getElementById('copy-btn-part2');
+    const splitWarning = document.getElementById('split-warning');
     const templateLength = template.length;
     const remaining = 1800 - templateLength;
     const indicator = document.getElementById('char-indicator');
@@ -988,7 +989,6 @@ ${nouveauSoldeCalc} - ${artisanatCostFormatted} = [SOLDE_ARTISANAT]`;
     }
 
     if (templateLength > 1800) {
-        alert("Le message dépasse 1 800 caractères. Il est divisé en deux parties.");
         const mid = Math.ceil(templateLength / 2);
         const part1 = template.slice(0, mid);
         const part2 = template.slice(mid);
@@ -1002,6 +1002,10 @@ ${nouveauSoldeCalc} - ${artisanatCostFormatted} = [SOLDE_ARTISANAT]`;
         if (copyBtnPart2) {
             copyBtnPart2.style.display = 'inline-block';
         }
+        if (splitWarning) {
+            splitWarning.textContent = '⚠️ Le message dépasse 1 800 caractères ; il a été divisé en deux parties';
+            splitWarning.style.display = 'block';
+        }
     } else {
         if (outputEl) {
             outputEl.textContent = template;
@@ -1012,6 +1016,10 @@ ${nouveauSoldeCalc} - ${artisanatCostFormatted} = [SOLDE_ARTISANAT]`;
         }
         if (copyBtnPart2) {
             copyBtnPart2.style.display = 'none';
+        }
+        if (splitWarning) {
+            splitWarning.textContent = '';
+            splitWarning.style.display = 'none';
         }
     }
 }

--- a/web/maj-fiche-styles.css
+++ b/web/maj-fiche-styles.css
@@ -195,6 +195,17 @@ input[disabled] {
     font-weight: bold;
 }
 
+.split-warning {
+    display: none;
+    color: #e67e22;
+    font-size: 0.9rem;
+    margin-bottom: 10px;
+}
+
+.split-warning::before {
+    content: "⚠️ ";
+}
+
 /* Système d'onglets */
 .tab-container {
     margin-bottom: 20px;


### PR DESCRIPTION
## Summary
- add hidden split warning container before Discord output
- style split warning with orange text and warning icon
- show split warning instead of alert when template exceeds 1,800 characters

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a77b256bf48327a6c7fef2c8080ab5