### PR TITLE
feat: improve clipboard copy with promise API

### DIFF
--- a/web/maj-fiche-dev.html
+++ b/web/maj-fiche-dev.html
@@ -382,11 +382,11 @@ Classe : Magicien
 **¤ Solde :**
 ANCIEN SOLDE [SOLDE] + [CHANGEMENTS] = [NOUVEAU_SOLDE]
 *Fiche R20 à jour.*</div>
-                <button class="copy-btn" data-target="discord-output" onclick="copyToClipboard(event)">
+                <button class="copy-btn" data-target="discord-output">
                     📋 Copier le Message
                 </button>
                 <div class="discord-output" id="discord-output-part2" style="display: none;"></div>
-                <button class="copy-btn" id="copy-btn-part2" data-target="discord-output-part2" onclick="copyToClipboard(event)" style="display: none;">
+                <button class="copy-btn" id="copy-btn-part2" data-target="discord-output-part2" style="display: none;">
                     📋 Copier la Partie 2
                 </button>
             </div>


### PR DESCRIPTION
## Summary
- refactor copy helper to use `navigator.clipboard.writeText` and return a promise
- add asynchronous handlers for copy buttons with visual feedback and error handling
- ensure copy buttons declare a valid `data-target` for the zone to copy

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a77fc34b54832791755bd1ab9bcd91