### PR TITLE
Améliore l'affichage détaillé du solde

### DIFF
--- a/web/maj-fiche-script.js
+++ b/web/maj-fiche-script.js
@@ -953,20 +953,24 @@ ${transactionsText}
     }
 
     // Calcul nouveau solde en convertissant toutes les monnaies des quêtes en PO
-    const changeTotal = poRecues + poLootees + questPO + netPOMarchand;
-    const changeTotalFormatted = changeTotal.toFixed(2);
+    const changeTotal = poRecues + poLootees + questPO + netPOMarchand - artisanatCost;
     const ancienSoldeAffiche = isNaN(ancienSoldeNum) ? ancienSolde : ancienSoldeNum.toFixed(2);
     const nouveauSoldeCalc = isNaN(ancienSoldeNum) ? '[NOUVEAU_SOLDE]' : (ancienSoldeNum + changeTotal).toFixed(2);
-    let soldeText;
-    if (changeTotal === 0) {
-        soldeText = `${ancienSoldeAffiche} inchangé`;
-    } else {
-        soldeText = `${ancienSoldeAffiche} ${changeTotal >= 0 ? '+' : ''}${changeTotalFormatted} = ${nouveauSoldeCalc}`;
-    }
+
+    const soldeLines = [];
+    soldeLines.push(`ANCIEN SOLDE ${ancienSoldeAffiche}`);
+
+    const formatChange = (val) => `${val >= 0 ? '+' : '-'}${Math.abs(val).toFixed(2)}`;
+    if (poRecues !== 0) soldeLines.push(formatChange(poRecues));
+    if (poLootees !== 0) soldeLines.push(formatChange(poLootees));
+    if (questPO !== 0) soldeLines.push(formatChange(questPO));
+    if (netPOMarchand !== 0) soldeLines.push(formatChange(netPOMarchand));
+    if (artisanatCost > 0) soldeLines.push(`-${artisanatCost.toFixed(2)}`);
+    soldeLines.push(`= ${nouveauSoldeCalc}`);
 
     template += `
 **¤ Solde :**
-ANCIEN SOLDE ${soldeText}
+${soldeLines.join('\n')}
 *Fiche R20 à jour.*`;
 
     const hasArtisanat = artisanatNotes || artisanatItemsList.length > 0 || artisanatCostRaw !== '';
@@ -978,15 +982,10 @@ ANCIEN SOLDE ${soldeText}
 Obtention des objets suivants :
 ${artisanatItemsList.map(i => `- ${i}`).join('\n')}`;
         }
-        const nouveauSoldeNum = parseFloat(nouveauSoldeCalc);
-        const artisanatCostFormatted = artisanatCost.toFixed(2);
-        if (!isNaN(nouveauSoldeNum)) {
-            const soldeApresArtisanat = (nouveauSoldeNum - artisanatCost).toFixed(2);
+        if (artisanatCost > 0) {
+            const artisanatCostFormatted = artisanatCost.toFixed(2);
             template += `
-${nouveauSoldeCalc} - ${artisanatCostFormatted} = ${soldeApresArtisanat}`;
-        } else {
-            template += `
-${nouveauSoldeCalc} - ${artisanatCostFormatted} = [SOLDE_ARTISANAT]`;
+Coût : ${artisanatCostFormatted} PO`;
         }
     }
 


### PR DESCRIPTION
## Summary
- Détaille chaque opération de trésorerie pour exposer le calcul du solde final
- Intègre le coût d'artisanat au calcul du solde et simplifie la section artisanat

## Testing
- `pytest`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a82e3c81388327848950d2c202e2ba