### PR TITLE
feat: support transaction quantities

### DIFF
--- a/web/maj-fiche-dev.html
+++ b/web/maj-fiche-dev.html
@@ -314,7 +314,7 @@
                             <label>Achats / Ventes :</label>
                             <div id="transactions-container"></div>
                             <button type="button" id="add-transaction">Ajouter une ligne</button>
-                            <div class="help-text">Format : ACHAT : Armure 45PO / VENTE : Bijou 100PO</div>
+                            <div class="help-text">Format : ACHAT : 2×Potion 15PO = 30PO / VENTE : Bijou 100PO</div>
                         </div>
                         <div class="form-group">
                             <label for="section-marchand">

--- a/web/maj-fiche-script.js
+++ b/web/maj-fiche-script.js
@@ -58,7 +58,8 @@ function addTransactionLine() {
             <option value="VENTE">VENTE</option>
         </select>
         <input type="text" placeholder="Description">
-        <input type="number" step="0.01" placeholder="0">
+        <input type="number" class="quantity" min="1" step="1" value="1" placeholder="1">
+        <input type="number" class="price" step="0.01" placeholder="0">
         <button type="button" class="delete-transaction">🗑️</button>
     `;
     container.appendChild(line);
@@ -799,14 +800,20 @@ function generateTemplate() {
         lines.forEach(line => {
             const type = line.querySelector('select')?.value;
             const desc = line.querySelector('input[type="text"]')?.value.trim();
-            const amountStr = line.querySelector('input[type="number"]')?.value;
-            const amount = parseFloat(amountStr);
-            if (type && desc && !isNaN(amount)) {
-                formatted.push(`${type} : ${desc} ${amount.toFixed(2)}PO`);
+            const qtyStr = line.querySelector('.quantity')?.value;
+            const qty = parseInt(qtyStr) || 1;
+            const priceStr = line.querySelector('.price')?.value;
+            const price = parseFloat(priceStr);
+            if (type && desc && !isNaN(price)) {
+                const subtotal = qty * price;
+                const lineText = qty > 1
+                    ? `${type} : ${qty}×${desc} ${price.toFixed(2)}PO = ${subtotal.toFixed(2)}PO`
+                    : `${type} : ${desc} ${subtotal.toFixed(2)}PO`;
+                formatted.push(lineText);
                 if (type === 'ACHAT') {
-                    netPOMarchand -= amount;
+                    netPOMarchand -= subtotal;
                 } else if (type === 'VENTE') {
-                    netPOMarchand += amount;
+                    netPOMarchand += subtotal;
                 }
             }
         });

--- a/web/maj-fiche-styles.css
+++ b/web/maj-fiche-styles.css
@@ -316,7 +316,7 @@ input[disabled] {
 
 .transaction-line {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(80px, 1fr));
+    grid-template-columns: auto 1fr 80px 100px auto;
     gap: 5px;
     align-items: center;
 }


### PR DESCRIPTION
## Summary
- add quantity inputs to transactions
- compute transaction subtotals and net merchant gold
- expand transaction grid layout

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a837b3704c8327a3cea9b3ca42c8f7