### PR TITLE
Avoid default placeholders for extra abilities and spells

### DIFF
--- a/web/maj-fiche-script.js
+++ b/web/maj-fiche-script.js
@@ -786,15 +786,15 @@ function generateTemplate() {
         return el.value.split(/[\n,]+/).map(s => s.trim()).filter(Boolean);
     };
 
-    const nouvellesCapacites = nouvellesCapacitesEl ? nouvellesCapacitesEl.value || '-' : '-';
+    const nouvellesCapacites = nouvellesCapacitesEl ? nouvellesCapacitesEl.value.trim() : '';
     const nouveauDonList = parseList(nouveauDonEl);
     const donQueteList = parseList(donQueteEl);
     const nouveauxSortsList = parseList(nouveauxSortsEl);
     const sortsRemplacesList = parseList(sortsRemplacesEl);
-    const nouveauxDons = nouveauDonList.length ? nouveauDonList.join(', ') : '-';
-    const donsQuete = donQueteList.length ? donQueteList.join(', ') : '-';
-    const nouveauxSorts = nouveauxSortsList.length ? nouveauxSortsList.join(', ') : '-';
-    const sortsRemplaces = sortsRemplacesList.length ? sortsRemplacesList.join(', ') : '-';
+    const nouveauxDons = nouveauDonList.join(', ');
+    const donsQuete = donQueteList.join(', ');
+    const nouveauxSorts = nouveauxSortsList.join(', ');
+    const sortsRemplaces = sortsRemplacesList.join(', ');
     
     // Items et argent
     const objetsLootesEl = document.getElementById('objets-lootes');
@@ -901,18 +901,27 @@ ${affichageXP}`;
         }
     }
 
-    template += `
+    const extras = [];
+    if (nouvellesCapacites) {
+        extras.push(`Nouvelle(s) capacité(s) :\n${nouvellesCapacites}`);
+    }
+    if (nouveauxDons) {
+        extras.push(`Nouveau(x) don(s) :\n${nouveauxDons}`);
+    }
+    if (donsQuete) {
+        extras.push(`Don(s) (gain de quête) :\n${donsQuete}`);
+    }
+    if (nouveauxSorts) {
+        extras.push(`Nouveau(x) sort(s) :\n${nouveauxSorts}`);
+    }
+    if (sortsRemplaces) {
+        extras.push(`Sort(s) remplacé(s) :\n${sortsRemplaces}`);
+    }
+    if (extras.length > 0) {
+        template += `
 **¤ Capacités et sorts supplémentaires :**
-Nouvelle(s) capacité(s) :
-${nouvellesCapacites}
-Nouveau(x) don(s) :
-${nouveauxDons}
-Don(s) (gain de quête) :
-${donsQuete}
-Nouveau(x) sort(s) :
-${nouveauxSorts}
-Sort(s) remplacé(s) :
-${sortsRemplaces}`;
+${extras.join('\n')}`;
+    }
 
     // Inventaire seulement si renseigné
     const objetsLootesBase = objetsLootes || '';


### PR DESCRIPTION
## Summary
- Don't populate new abilities, feats, or spells with placeholder dashes
- Only add the "Capacités et sorts supplémentaires" block when at least one field has content

## Testing
- `node --check web/maj-fiche-script.js`
- `python -m py_compile $(git ls-files '*.py')`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a86470e6dc8327993557cbcebf95c1