### PR TITLE
Clear default values from optional sections

### DIFF
--- a/web/maj-fiche-dev.html
+++ b/web/maj-fiche-dev.html
@@ -369,19 +369,7 @@
                 <h3 class="preview-title">📝 Aperçu Discord</h3>
                 <div id="char-indicator" class="char-indicator"></div>
                 <div id="split-warning" class="split-warning" style="display:none;"></div>
-                <div class="discord-output" id="discord-output">Nom du PJ : Gandalf le Gris
-Classe : Magicien
-
-** / =======================  PJ  ========================= \ **
-**Quête :** [
-- La Tour du Mage Noir + @MasterJean ⁠- https://discord.com/channels/123456789/987654321/111222333, +3 XP, +150 PO, +Baguette de Boules de Feu (+1)
-] +3 XP
-**Solde XP :** 8/5 + 3XP obtenue = 11 ==> 11/5 ==> passage au niveau 12 Magicien ✅
-**Gain de niveau :** Niveau 11 → **Niveau 12** 🎉
-** \ =======================  PJ  ========================= / **
-**¤ Solde :**
-ANCIEN SOLDE [SOLDE] + [CHANGEMENTS] = [NOUVEAU_SOLDE]
-*Fiche R20 à jour.*</div>
+                <div class="discord-output" id="discord-output"></div>
                 <button class="copy-btn" data-target="discord-output">
                     📋 Copier le Message
                 </button>

--- a/web/maj-fiche-script.js
+++ b/web/maj-fiche-script.js
@@ -58,7 +58,7 @@ function addTransactionLine() {
             <option value="VENTE">VENTE</option>
         </select>
         <input type="text" placeholder="Description">
-        <input type="number" class="quantity" min="1" step="1" value="1" placeholder="1">
+        <input type="number" class="quantity" min="1" step="1" placeholder="1">
         <input type="number" class="price" step="0.01" placeholder="0">
         <button type="button" class="delete-transaction">🗑️</button>
     `;
@@ -279,7 +279,7 @@ function createQueteHTML(index) {
 
             <div class="form-group">
                 <label for="xp-quete-${index}">XP de cette quête :</label>
-                <input type="number" id="xp-quete-${index}" placeholder="1" min="0" max="10" value="1">
+                <input type="number" id="xp-quete-${index}" placeholder="1" min="0" max="10">
             </div>
 
             <div class="checkbox-group">


### PR DESCRIPTION
## Summary
- Ensure Discord preview is empty on load
- Remove preset values from transaction and quest templates so optional sections start blank

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a86d141f388327a37b9bd19131db64