### PR TITLE
Guard PJ section rendering on content presence

### DIFF
--- a/web/maj-fiche-script.js
+++ b/web/maj-fiche-script.js
@@ -871,9 +871,11 @@ ${descriptionSpecial}
     }
 
     // Section PJ principale
-    template += `
+    if (sectionQuete) {
+        template += `
 ** / =======================  PJ  ========================= \\ **
 ${sectionQuete}`;
+    }
 
     // XP seulement si renseignés
     if (xpActuels >= 0 && totalXPQuetes > 0) {


### PR DESCRIPTION
## Summary
- Only append the PJ section to the template when `sectionQuete` contains data, avoiding empty PJ blocks.

## Testing
- `node --check web/maj-fiche-script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b427bb1c8327b2ef90db7a91f0a9