### PR TITLE
Add artisanat toggle section

### DIFF
--- a/web/maj-fiche-dev.html
+++ b/web/maj-fiche-dev.html
@@ -345,17 +345,20 @@
                         </div>
                     </div>
                     <div id="tab-special" class="tab-content">
-                        <div class="form-group">
-                            <label for="artisanat-notes">Notes d'artisanat :</label>
-                            <textarea id="artisanat-notes" rows="3" placeholder="Notes sur l'artisanat..."></textarea>
-                        </div>
-                        <div class="form-group">
-                            <label for="artisanat-items">Objets fabriqués (un par ligne) :</label>
-                            <textarea id="artisanat-items" rows="3" placeholder="Potion de soin\nPotion de mana"></textarea>
-                        </div>
-                        <div class="form-group">
-                            <label for="artisanat-cost">Coût total d'artisanat :</label>
-                            <input type="number" id="artisanat-cost" placeholder="0">
+                        <button type="button" id="toggle-artisanat-btn">Ajouter artisanat</button>
+                        <div id="artisanat-section" class="hidden">
+                            <div class="form-group">
+                                <label for="artisanat-notes">Notes d'artisanat :</label>
+                                <textarea id="artisanat-notes" rows="3" placeholder="Notes sur l'artisanat..."></textarea>
+                            </div>
+                            <div class="form-group">
+                                <label for="artisanat-items">Objets fabriqués (un par ligne) :</label>
+                                <textarea id="artisanat-items" rows="3" placeholder="Potion de soin\nPotion de mana"></textarea>
+                            </div>
+                            <div class="form-group">
+                                <label for="artisanat-cost">Coût total d'artisanat :</label>
+                                <input type="number" id="artisanat-cost" placeholder="0">
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/web/maj-fiche-script.js
+++ b/web/maj-fiche-script.js
@@ -1081,6 +1081,15 @@ function copyToClipboard(text) {
     });
 }
 
+function toggleArtisanat() {
+    const section = document.getElementById('artisanat-section');
+    const btn = document.getElementById('toggle-artisanat-btn');
+    if (!section || !btn) return;
+
+    const isHidden = section.classList.toggle('hidden');
+    btn.textContent = isHidden ? 'Ajouter artisanat' : 'Retirer artisanat';
+}
+
 // ===== INITIALISATION =====
 
 document.addEventListener('DOMContentLoaded', function() {
@@ -1103,6 +1112,12 @@ document.addEventListener('DOMContentLoaded', function() {
             
             regenerateIfNeeded();
         });
+    }
+
+    // Gestion du toggle artisanat
+    const artisanatBtn = document.getElementById('toggle-artisanat-btn');
+    if (artisanatBtn) {
+        artisanatBtn.addEventListener('click', toggleArtisanat);
     }
 
     // Setup des listeners pour la première quête
@@ -1161,10 +1176,15 @@ document.addEventListener('DOMContentLoaded', function() {
         + ' textarea#artisanat-notes:not([data-listener-added]),'
         + ' textarea#artisanat-items:not([data-listener-added]),'
         + ' input#artisanat-cost:not([data-listener-added]),'
-        + ' input#section-marchand:not([data-listener-added])'
+        + ' input#section-marchand:not([data-listener-added]),'
+        + ' button#toggle-artisanat-btn:not([data-listener-added])'
     );
     inputs.forEach(input => {
-        input.addEventListener('input', regenerateIfNeeded);
+        if (input.tagName === 'BUTTON') {
+            input.addEventListener('click', regenerateIfNeeded);
+        } else {
+            input.addEventListener('input', regenerateIfNeeded);
+        }
         input.setAttribute('data-listener-added', 'true');
     });
 


### PR DESCRIPTION
## Summary
- Add toggle button and hidden container for artisanat fields
- Implement `toggleArtisanat` and register button during setup
- Include artisanat toggle in regeneration listeners

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a8b767b3008327b965d8ec3d10a400