### PR TITLE
Déplacer la fermeture de section PJ après le solde

### DIFF
--- a/web/maj-fiche-script.js
+++ b/web/maj-fiche-script.js
@@ -860,6 +860,7 @@ function generateTemplate() {
     // Construction du template
     let template = `Nom du PJ : ${nom}
 Classe : ${classe}`;
+    let pjSectionOpened = false;
 
     // Section spéciale si définie
     if (typeSpecial && descriptionSpecial) {
@@ -872,6 +873,7 @@ ${descriptionSpecial}
 
     // Section PJ principale
     if (sectionQuete) {
+        pjSectionOpened = true;
         template += `
 ** / =======================  PJ  ========================= \\ **
 ${sectionQuete}`;
@@ -968,9 +970,6 @@ Monnaies lootées: ${monnaiesText}`;
         }
     }
 
-    template += `
-** \\ =======================  PJ  ========================= / **`;
-
     // Section Marchand si demandée
     if (includeMarchand && transactionsText.trim() !== '') {
         template += `
@@ -999,6 +998,11 @@ ${transactionsText}
 **¤ Solde :**
 ${soldeLines.join('\n')}
 *Fiche R20 à jour.*`;
+
+    if (pjSectionOpened) {
+        template += `
+** \ =======================  PJ  ========================= / **`;
+    }
 
     const hasArtisanat = artisanatNotes || artisanatItemsList.length > 0 || artisanatCostRaw !== '';
     if (hasArtisanat) {


### PR DESCRIPTION
## Summary
- Déplace la fermeture de la section PJ après la section de solde
- Ferme la section PJ uniquement si elle a été ouverte

## Testing
- `node --check web/maj-fiche-script.js`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a8d25530048327903d820efbedd70c