### PR TITLE
Ensure PJ delimiters always close

### DIFF
--- a/web/maj-fiche-script.js
+++ b/web/maj-fiche-script.js
@@ -848,12 +848,10 @@ function generateTemplate() {
     const typeSpecialEl = document.getElementById('type-special');
     const descriptionSpecialEl = document.getElementById('description-special');
     const includeMarchandEl = document.getElementById('section-marchand');
-    const addPjDelimiterEl = document.getElementById('add-pj-delimiter');
 
     const typeSpecial = typeSpecialEl ? typeSpecialEl.value : '';
     const descriptionSpecial = descriptionSpecialEl ? descriptionSpecialEl.value : '';
     const includeMarchand = includeMarchandEl ? includeMarchandEl.checked : false;
-    const addPjDelimiter = addPjDelimiterEl ? addPjDelimiterEl.checked : false;
     
     // Calculs
     const { progressionText, xpInfo } = calculateXPProgression(xpActuels, totalXPQuetes, niveauActuel, niveauCible, classeGainNiveau || classe);
@@ -1002,7 +1000,7 @@ ${soldeLines.join('\n')}
 *Fiche R20 à jour.*`;
 
 
-    if (pjSectionOpened && addPjDelimiter) {
+    if (pjSectionOpened) {
         template += `
 ** \ =======================  PJ  ========================= / **`;
     }


### PR DESCRIPTION
## Summary
- remove unused PJ delimiter flag and related checkbox logic
- always append closing PJ delimiter in generated templates

## Testing
- `node <<'NODE'
let template='';
let pjSectionOpened=false;
const sectionQuete='Contenu';
if(sectionQuete){ pjSectionOpened=true; template+=`\n** / =======================  PJ  ========================= \\ **\n${sectionQuete}`; }
if(pjSectionOpened){ template+=`\n** \\ =======================  PJ  ========================= / **`; }
console.log(template);
NODE`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a99df1aeb883279e4ab24d0fdf185d