### PR TITLE
Make Disboard bump reminder ephemeral (whisper)

### DIFF
--- a/commands/disboard_bump.py
+++ b/commands/disboard_bump.py
@@ -8,7 +8,7 @@ DESCRIPTION:
 FONCTIONNEMENT:
     - Vérifie si 2h se sont écoulées depuis le dernier bump
     - Si cooldown actif : message éphémère avec le temps restant
-    - Si disponible : enregistre le timestamp et envoie un rappel public
+    - Si disponible : enregistre le timestamp et envoie un rappel éphémère (whisper)
       pour que quelqu'un utilise la commande /bump de Disboard
 
 UTILISATION:
@@ -157,4 +157,4 @@ class DisboardBumpCommand(BaseCommand):
             inline=False)
         embed.set_footer(text=f"Bumped par {interaction.user.display_name} • Prochain bump dans 2h")
 
-        await interaction.response.send_message(embed=embed)
+        await interaction.response.send_message(embed=embed, ephemeral=True)


### PR DESCRIPTION
## Summary
Changed the Disboard bump reminder message to be sent as an ephemeral message (whisper) instead of a public message, making it only visible to the user who triggered the command.

## Changes
- Updated the bump success message to use `ephemeral=True` parameter when sending the embed response
- Updated the docstring to clarify that the reminder is now sent as an ephemeral message (whisper) rather than public

## Details
This change improves the user experience by reducing noise in the channel. The bump confirmation message is now only visible to the user who executed the bump command, while still providing them with confirmation and the next bump time. This is more appropriate for a reminder message that doesn't require visibility to the entire server.

https://claude.ai/code/session_015Z2o2i7ZM17AJR2JuDegSu